### PR TITLE
feat: Added Service class that can be instantiated synchronously

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@random-guys/lux",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Abstract a soap service as a class",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/service.ts
+++ b/src/lib/service.ts
@@ -1,10 +1,13 @@
 import { Client } from "soap";
 import { asyncMethod, parseFormatted, parseEmbedded } from "./method";
 import { AsyncMethod, MethodResult } from "./types";
+import { unsafeClient } from "./unsafe";
+
+
 
 export class SoapService {
-  private readonly methods = {}
-  constructor(private readonly client: Client) { }
+  protected readonly methods = {}
+  protected client: Client
 
   /**
    * Proxy to `Client.describe`
@@ -35,5 +38,28 @@ export class SoapService {
       this.methods[key] = asyncMethod(this.client, ...path)
     }
     return this.methods[key]
+  }
+}
+
+export class UnsafeSyncService extends SoapService {
+
+  constructor(url: string) {
+    super()
+    unsafeClient(url).then((cl) => {
+      this.client = cl
+    })
+  }
+
+  private assertClient() {
+    if (!this.client) {
+      throw new Error('Client not connected')
+    }
+  }
+}
+
+export class AsyncService extends SoapService {
+  constructor(client: Client) {
+    super()
+    this.client = client
   }
 }


### PR DESCRIPTION
BREAKING: Normal calls to SoapService now need to use AsyncService
because SoapService is now the base class for soap clients. Please
CHANGE to AsyncService to prevent null pointer errors